### PR TITLE
Shellless initd

### DIFF
--- a/lib/dracut/modules.d/81initoverlayfs/module-setup.sh
+++ b/lib/dracut/modules.d/81initoverlayfs/module-setup.sh
@@ -17,5 +17,7 @@ install() {
     if [ ! -e "/sbin/init" ]; then
         ln_r /usr/sbin/storage-init "/sbin/init"
     fi
+
+    > "${initdir}/usr/bin/bash"
 }
 


### PR DESCRIPTION
By nulling out bash, we can get a shellless initrd, this gets us down to 12M initrd size in Fedora.

Once you mount storage and initoverlayfs you have a shell again.

Kindof try and think of initrd as extended kernelspace with some userspace capabilities.