### PR TITLE
systemd port

### DIFF
--- a/bin/initoverlayfs-install
+++ b/bin/initoverlayfs-install
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 # Constants with default value
 CAT="lz4cat"
@@ -59,9 +59,7 @@ exec_ext4() {
 }
 
 detect_initramfs() {
-    if [ ! -d "${INITRAMFS_DUMP_DIR}" ]; then
-        mkdir -p "${INITRAMFS_DUMP_DIR}"
-    fi
+    mkdir -p "${INITRAMFS_DUMP_DIR}"
 
     echo "Extracting initrd into initoverlayfs..."
 
@@ -165,9 +163,7 @@ if ! [ -e "$INITOVERLAYFS_CONF" ] || ! grep -q '[^[:space:]]' "$INITOVERLAYFS_CO
          "bootfs $boot_partition" \
          "bootfstype ext4" \
          "initoverlayfs_builder dracut -H -f -v -M --reproducible -o \"initoverlayfs\"" \
-         "initrd_builder dracut -H -f -v -M --reproducible -m \"kernel-modules udev-rules initoverlayfs\" -o \"bash systemd systemd-initrd i18n kernel-modules-extra rootfs-block dracut-systemd usrmount base fs-lib microcode_ctl-fw_dir_override shutdown nss-softokn\"" \
-         "udev_trigger udevadm trigger --type=devices --action=add --subsystem-match=module --subsystem-match=block --subsystem-match=virtio --subsystem-match=pci --subsystem-match=nvme --subsystem-match=mmc --subsystem-match=mmc_host --subsystem-match=platform" \
-         "udev_trigger_generic udevadm trigger --type=devices --action=add" > $INITOVERLAYFS_CONF
+         "initrd_builder dracut -H -f -v -M --reproducible -m \"kernel-modules udev-rules initoverlayfs systemd base\" -o \"bash systemd-initrd i18n kernel-modules-extra rootfs-block dracut-systemd usrmount fs-lib microcode_ctl-fw_dir_override shutdown nss-softokn\"" > $INITOVERLAYFS_CONF
 
   erofs_compression_supported="true"
   # shellcheck disable=SC2034

--- a/config-parser.h
+++ b/config-parser.h
@@ -12,15 +12,9 @@ static inline int conf_construct(conf* c) {
   c->fs.scoped = (str*)calloc(1, sizeof(str));
   c->fstype.val = (str*)calloc(1, sizeof(str));
   c->fstype.scoped = (str*)calloc(1, sizeof(str));
-  c->udev_trigger.val = (str*)calloc(1, sizeof(str));
-  c->udev_trigger.scoped = (str*)calloc(1, sizeof(str));
-  c->udev_trigger_generic.val = (str*)calloc(1, sizeof(str));
-  c->udev_trigger_generic.scoped = (str*)calloc(1, sizeof(str));
   return !c->bootfs.val || !c->bootfs.scoped || !c->bootfstype.val ||
          !c->bootfstype.scoped || !c->fs.val || !c->fs.scoped ||
-         !c->fstype.val || !c->fstype.scoped || !c->udev_trigger.val ||
-         !c->udev_trigger.scoped || !c->udev_trigger_generic.val ||
-         !c->udev_trigger_generic.scoped;
+         !c->fstype.val || !c->fstype.scoped;
 }
 
 static inline void set_conf(pair* conf, str** line, const size_t key_len) {
@@ -42,11 +36,6 @@ static inline void conf_set_pick(conf* c, str** line) {
                               .len = sizeof("bootfstype") - 1};
   const str fs_str = {.c_str = "fs", .len = sizeof("fs") - 1};
   const str fstype_str = {.c_str = "fstype", .len = sizeof("fstype") - 1};
-  const str udev_trigger_str = {.c_str = "udev_trigger",
-                                .len = sizeof("udev_trigger") - 1};
-  const str udev_trigger_generic_str = {
-      .c_str = "udev_trigger_generic",
-      .len = sizeof("udev_trigger_generic") - 1};
 
   if (is_line_key(*line, &bootfs_str))
     set_conf(&c->bootfs, line, bootfs_str.len);
@@ -56,23 +45,16 @@ static inline void conf_set_pick(conf* c, str** line) {
     set_conf(&c->fs, line, fs_str.len);
   else if (is_line_key(*line, &fstype_str))
     set_conf(&c->fstype, line, fstype_str.len);
-  else if (is_line_key(*line, &udev_trigger_str))
-    set_conf(&c->udev_trigger, line, udev_trigger_str.len);
-  else if (is_line_key(*line, &udev_trigger_generic_str))
-    set_conf(&c->udev_trigger_generic, line, udev_trigger_generic_str.len);
 }
 
 static inline conf* conf_print(conf* c) {
 #ifdef DEBUG
   printd(
       "bootfs: {\"%s\", \"%s\"}, bootfstype: {\"%s\", \"%s\"}, fs: {\"%s\", "
-      "\"%s\"}, fstype: {\"%s\", \"%s\"}, udev_trigger: {\"%s\", \"%s\"}, "
-      "udev_trigger_generic: {\"%s\", \"%s\"}\n",
+      "\"%s\"}, fstype: {\"%s\", \"%s\"}\n",
       c->bootfs.val->c_str, c->bootfs.scoped->c_str, c->bootfstype.val->c_str,
       c->bootfstype.scoped->c_str, c->fs.val->c_str, c->fs.scoped->c_str,
-      c->fstype.val->c_str, c->fstype.scoped->c_str, c->udev_trigger.val->c_str,
-      c->udev_trigger.scoped->c_str, c->udev_trigger_generic.val->c_str,
-      c->udev_trigger_generic.scoped->c_str);
+      c->fstype.val->c_str, c->fstype.scoped->c_str);
 #endif
   return c;
 }

--- a/initoverlayfs.spec.in
+++ b/initoverlayfs.spec.in
@@ -7,9 +7,9 @@ URL:           https://github.com/containers/initoverlayfs
 Source0:       %{url}/archive/%{version}/%{name}-%{version}.tar.gz
 
 BuildRequires: gcc
-Recommends: erofs-utils
 Recommends: lz4
 Recommends: gzip
+Requires: erofs-utils
 Requires: dracut
 
 %global debug_package %{nil}
@@ -26,16 +26,22 @@ gcc ${RPM_OPT_FLAGS} storage-init.c -o storage-init
 
 %install
 install -D -m755 bin/initoverlayfs-install ${RPM_BUILD_ROOT}/%{_bindir}/initoverlayfs-install
-install -D -m755 storage-init ${RPM_BUILD_ROOT}/%{_prefix}/sbin/storage-init
-install -D -m755 lib/dracut/modules.d/81initoverlayfs/module-setup.sh $RPM_BUILD_ROOT/%{_prefix}/lib/dracut/modules.d/81initoverlayfs/module-setup.sh
+install -D -m755 storage-init ${RPM_BUILD_ROOT}/%{_sbindir}/storage-init
+install -D -m755 lib/dracut/modules.d/81initoverlayfs/module-setup.sh ${RPM_BUILD_ROOT}/%{_prefix}/lib/dracut/modules.d/81initoverlayfs/module-setup.sh
+install -D -m644 lib/systemd/system/pre-initoverlayfs.target ${RPM_BUILD_ROOT}/%{_prefix}/lib/systemd/system/pre-initoverlayfs.target
+install -D -m644 lib/systemd/system/pre-initoverlayfs.service ${RPM_BUILD_ROOT}/%{_prefix}/lib/systemd/system/pre-initoverlayfs.service
+install -D -m644 lib/systemd/system/pre-initoverlayfs-switch-root.service ${RPM_BUILD_ROOT}/%{_prefix}/lib/systemd/system/pre-initoverlayfs-switch-root.service
 
 %files
 %license LICENSE
 %doc README.md
 %attr(0755,root,root)
 %{_bindir}/initoverlayfs-install
-%{_prefix}/sbin/storage-init
+%{_sbindir}/storage-init
 %{_prefix}/lib/dracut/modules.d/81initoverlayfs/
+%{_prefix}/lib/systemd/system/pre-initoverlayfs.target
+%{_prefix}/lib/systemd/system/pre-initoverlayfs.service
+%{_prefix}/lib/systemd/system/pre-initoverlayfs-switch-root.service
 
 %changelog
 * Thu Dec 14 2023 Stephen Smoogen <ssmoogen@redhat.com> - 0.99-1

--- a/lib/systemd/system/pre-initoverlayfs-switch-root.service
+++ b/lib/systemd/system/pre-initoverlayfs-switch-root.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Switch Root pre-initoverlayfs
+AssertPathExists=/etc/initrd-release
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+AllowIsolate=yes
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+Before=sysinit.target pre-initoverlayfs.target
+After=systemd-journald.service pre-initoverlayfs.service
+
+[Service]
+Type=oneshot
+ExecStart=systemctl --no-block switch-root /initoverlayfs
+

--- a/lib/systemd/system/pre-initoverlayfs.service
+++ b/lib/systemd/system/pre-initoverlayfs.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=pre-initoverlayfs initialization
+AssertPathExists=/etc/initrd-release
+DefaultDependencies=no
+ConditionPathExists=/etc/initrd-release
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+Before=sysinit.target pre-initoverlayfs.target
+After=systemd-journald.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/storage-init
+StandardInput=null
+StandardOutput=journal+console
+StandardError=journal+console
+RemainAfterExit=yes
+

--- a/lib/systemd/system/pre-initoverlayfs.target
+++ b/lib/systemd/system/pre-initoverlayfs.target
@@ -1,0 +1,9 @@
+[Unit]
+Description=pre-initoverlayfs Default Target
+OnFailure=emergency.target
+OnFailureJobMode=replace-irreversibly
+AssertPathExists=/etc/initrd-release
+Requires=basic.target
+After=pre-initoverlayfs.service rescue.target
+AllowIsolate=yes
+

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -ex
+
+REL="$(git tag | tail -1)"
+mkdir -p "$HOME/rpmbuild/SOURCES/"
+git archive -o "$HOME/rpmbuild/SOURCES/initoverlayfs-$REL.tar.gz" --prefix "initoverlayfs-$REL/" HEAD
+./build-scripts/create-spec.sh
+rpmbuild_output=$(rpmbuild -bb initoverlayfs.spec 2>&1)
+rpm_to_install=$(echo "$rpmbuild_output" | grep "Wrote:" | awk '{print $2}')
+if rpm -Uvh "$rpm_to_install"; then
+  echo "$rpmbuild_output"
+fi
+
+initoverlayfs-install
+

--- a/storage-init.h
+++ b/storage-init.h
@@ -63,8 +63,6 @@ typedef struct conf {
   pair bootfstype;
   pair fs;
   pair fstype;
-  pair udev_trigger;
-  pair udev_trigger_generic;
 } conf;
 
 static inline void cleanup_free_conf(conf* p) {
@@ -76,23 +74,15 @@ static inline void cleanup_free_conf(conf* p) {
     free(p->fs.scoped->c_str);
   if (p->fstype.scoped)
     free(p->fstype.scoped->c_str);
-  if (p->udev_trigger.scoped)
-    free(p->udev_trigger.scoped->c_str);
-  if (p->udev_trigger_generic.scoped)
-    free(p->udev_trigger_generic.scoped->c_str);
 
   free(p->bootfs.scoped);
   free(p->bootfstype.scoped);
   free(p->fs.scoped);
   free(p->fstype.scoped);
-  free(p->udev_trigger.scoped);
-  free(p->udev_trigger_generic.scoped);
   free(p->bootfs.val);
   free(p->bootfstype.val);
   free(p->fs.val);
   free(p->fstype.val);
-  free(p->udev_trigger.val);
-  free(p->udev_trigger_generic.val);
 }
 
 static inline void cleanup_free(void* p) {


### PR DESCRIPTION
We now fork storage-init as a systemd unit. early systemd-udev
responsibility is now back under the control of systemd. early
switch-root is now back under the control of systemd. logging
is now back under the control of systemd.

Signed-off-by: Eric Curtin <ecurtin@redhat.com>
