### PR TITLE
Remove /dev/kmsg code

### DIFF
--- a/storage-init.c
+++ b/storage-init.c
@@ -107,17 +107,6 @@ static inline void execl_single_arg(const char* exe) {
   execl(exe, exe, (char*)NULL);
 }
 
-static inline FILE* log_open_kmsg(void) {
-  kmsg_f = fopen("/dev/kmsg", "w");
-  if (!kmsg_f) {
-    print("open(\"/dev/kmsg\", \"w\"), %d = errno\n", errno);
-    return kmsg_f;
-  }
-
-  setvbuf(kmsg_f, 0, _IOLBF, 0);
-  return kmsg_f;
-}
-
 static inline long loop_ctl_get_free(void) {
   autoclose const int loopctlfd = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
   if (loopctlfd < 0) {

--- a/storage-init.h
+++ b/storage-init.h
@@ -28,11 +28,6 @@
 
 #define print(...)                                   \
   do {                                               \
-    if (kmsg_f) {                                    \
-      fprintf(kmsg_f, "storage-init: " __VA_ARGS__); \
-      break;                                         \
-    }                                                \
-                                                     \
     printf(__VA_ARGS__);                             \
   } while (0)
 
@@ -45,8 +40,6 @@
 #else
 #define printd(...)
 #endif
-
-static FILE* kmsg_f = 0;
 
 typedef struct str {
   char* c_str;


### PR DESCRIPTION
We now rely on the init system for logging.