### PR TITLE
initoverlayfs-install fixes

### DIFF
--- a/bin/initoverlayfs-install
+++ b/bin/initoverlayfs-install
@@ -159,10 +159,11 @@ detect_path_initramfs
 
 if ! [ -e "$INITOVERLAYFS_CONF" ] || ! grep -q '[^[:space:]]' "$INITOVERLAYFS_CONF"; then
   boot_partition=$(< /etc/fstab grep "${INITRAMFS_DIR}.*ext4" | awk '{print $1}')
-  printf "%s\n%s\n%s\n%s\n%s\n%s\n" \
+
+  printf "%s\n%s\n%s\n%s\n" \
          "bootfs $boot_partition" \
          "bootfstype ext4" \
-         "initoverlayfs_builder dracut -N -f -v -M --reproducible -o \"initoverlayfs\"" \
+         "initoverlayfs_builder dracut -N -f -v -M --reproducible -o \"initoverlayfs fcoe\"" \
          "initrd_builder dracut -N -f -v -M --reproducible -m \"kernel-modules udev-rules initoverlayfs systemd base\" -o \"bash systemd-initrd i18n kernel-modules-extra rootfs-block dracut-systemd usrmount fs-lib microcode_ctl-fw_dir_override shutdown nss-softokn\"" > $INITOVERLAYFS_CONF
 
   erofs_compression_supported="true"
@@ -184,11 +185,11 @@ fi
 
 erofs_compression=$(sed -ne "s/^erofs_compression\s//pg" "$INITOVERLAYFS_CONF")
 initoverlayfs_builder=$(sed -ne "s/^initoverlayfs_builder\s//pg" "$INITOVERLAYFS_CONF")
-/bin/bash -c "$initoverlayfs_builder"
+/bin/bash -c "$initoverlayfs_builder --kver $kver"
 
 detect_initramfs
 extract_initrd_into_initoverlayfs
 
 initrd_builder=$(sed -ne "s/^initrd_builder\s//pg" "$INITOVERLAYFS_CONF")
-/bin/bash -c "$initrd_builder"
+/bin/bash -c "$initrd_builder --kver $kver"
 


### PR DESCRIPTION
Add kver to builder. Pass --kver to dracut everytime, so not assume uname kver is the one we want. Remove fcoe from initoverlayfs causing issues in latest Fedora.