### PR TITLE
Add support for bootfs_hint during installation

### DIFF
--- a/bin/initoverlayfs-install
+++ b/bin/initoverlayfs-install
@@ -153,10 +153,12 @@ fi
 detect_path_initramfs
 
 if ! [ -e "$INITOVERLAYFS_CONF" ] || ! grep -q '[^[:space:]]' "$INITOVERLAYFS_CONF"; then
-  boot_partition=$(< /etc/fstab grep "${INITRAMFS_DIR}.*ext4" | awk '{print $1}')
+  boot_partition=$(grep "${INITRAMFS_DIR}.*ext4" /etc/fstab | awk '{print $1}')
+  boot_partition_hint=$(blkid -t $boot_partition | awk -F: '{print $1}')
 
-  printf "%s\n%s\n%s\n%s" \
+  printf "%s\n%s\n%s\n%s\n" \
          "bootfs $boot_partition" \
+         "bootfs_hint $boot_partition_hint" \
          "bootfstype ext4" \
          "initoverlayfs_builder dracut -M -o \"initoverlayfs fcoe\"" > $INITOVERLAYFS_CONF
 

--- a/config-parser.h
+++ b/config-parser.h
@@ -6,13 +6,16 @@ static inline bool is_line_key(const str* line, const str* key) {
 static inline int conf_construct(conf* c) {
   c->bootfs.val = (str*)calloc(1, sizeof(str));
   c->bootfs.scoped = (str*)calloc(1, sizeof(str));
+  c->bootfs_hint.val = (str*)calloc(1, sizeof(str));
+  c->bootfs_hint.scoped = (str*)calloc(1, sizeof(str));
   c->bootfstype.val = (str*)calloc(1, sizeof(str));
   c->bootfstype.scoped = (str*)calloc(1, sizeof(str));
   c->fs.val = (str*)calloc(1, sizeof(str));
   c->fs.scoped = (str*)calloc(1, sizeof(str));
   c->fstype.val = (str*)calloc(1, sizeof(str));
   c->fstype.scoped = (str*)calloc(1, sizeof(str));
-  return !c->bootfs.val || !c->bootfs.scoped || !c->bootfstype.val ||
+  return !c->bootfs.val || !c->bootfs.scoped || !c->bootfs_hint.val ||
+         !c->bootfs_hint.scoped || !c->bootfstype.val ||
          !c->bootfstype.scoped || !c->fs.val || !c->fs.scoped ||
          !c->fstype.val || !c->fstype.scoped;
 }
@@ -32,6 +35,8 @@ static inline void set_conf(pair* conf, str** line, const size_t key_len) {
 
 static inline void conf_set_pick(conf* c, str** line) {
   const str bootfs_str = {.c_str = "bootfs", .len = sizeof("bootfs") - 1};
+  const str bootfs_hint_str = {.c_str = "bootfs_hint",
+                               .len = sizeof("bootfs_hint") - 1};
   const str bootfstype_str = {.c_str = "bootfstype",
                               .len = sizeof("bootfstype") - 1};
   const str fs_str = {.c_str = "fs", .len = sizeof("fs") - 1};
@@ -39,6 +44,8 @@ static inline void conf_set_pick(conf* c, str** line) {
 
   if (is_line_key(*line, &bootfs_str))
     set_conf(&c->bootfs, line, bootfs_str.len);
+  else if (is_line_key(*line, &bootfs_hint_str))
+    set_conf(&c->bootfs_hint, line, bootfs_hint_str.len);
   else if (is_line_key(*line, &bootfstype_str))
     set_conf(&c->bootfstype, line, bootfstype_str.len);
   else if (is_line_key(*line, &fs_str))
@@ -50,9 +57,11 @@ static inline void conf_set_pick(conf* c, str** line) {
 static inline conf* conf_print(conf* c) {
 #ifdef DEBUG
   printd(
-      "bootfs: {\"%s\", \"%s\"}, bootfstype: {\"%s\", \"%s\"}, fs: {\"%s\", "
+      "bootfs: {\"%s\", \"%s\"}, bootfs_hint: {\"%s\", \"%s\"}, bootfstype: "
+      "{\"%s\", \"%s\"}, fs: {\"%s\", "
       "\"%s\"}, fstype: {\"%s\", \"%s\"}\n",
-      c->bootfs.val->c_str, c->bootfs.scoped->c_str, c->bootfstype.val->c_str,
+      c->bootfs.val->c_str, c->bootfs.scoped->c_str, c->bootfs_hint.val->c_str,
+      c->bootfs_hint.scoped->c_str, c->bootfstype.val->c_str,
       c->bootfstype.scoped->c_str, c->fs.val->c_str, c->fs.scoped->c_str,
       c->fstype.val->c_str, c->fstype.scoped->c_str);
 #endif

--- a/initoverlayfs.h
+++ b/initoverlayfs.h
@@ -60,6 +60,7 @@ typedef struct pair {
 
 typedef struct conf {
   pair bootfs;
+  pair bootfs_hint;
   pair bootfstype;
   pair fs;
   pair fstype;
@@ -68,6 +69,8 @@ typedef struct conf {
 static inline void cleanup_free_conf(conf* p) {
   if (p->bootfs.scoped)
     free(p->bootfs.scoped->c_str);
+  if (p->bootfs_hint.scoped)
+    free(p->bootfs_hint.scoped->c_str);
   if (p->bootfstype.scoped)
     free(p->bootfstype.scoped->c_str);
   if (p->fs.scoped)
@@ -76,10 +79,12 @@ static inline void cleanup_free_conf(conf* p) {
     free(p->fstype.scoped->c_str);
 
   free(p->bootfs.scoped);
+  free(p->bootfs_hint.scoped);
   free(p->bootfstype.scoped);
   free(p->fs.scoped);
   free(p->fstype.scoped);
   free(p->bootfs.val);
+  free(p->bootfs_hint.val);
   free(p->bootfstype.val);
   free(p->fs.val);
   free(p->fstype.val);


### PR DESCRIPTION
This introduces support for bootfs_hint in the initoverlayfs installation process. The bootfs_hint is now parsed from the configuration file and utilized during the mounting bootfs. If a bootfs_hint is provided and matches the metadata of the expected bootfs (say PARTLABEL, PARTUUID as examples), it is used directly without performing a blkid lookup. This optimization aims to improve performance and efficiency during the bootfs mounting process.

Changes:
- Added parsing and utilization of bootfs_hint in initoverlayfs installation.
- Uses bootfs_hint if available and matching.
- Updated data structure and cleanup routines to handle bootfs_hint.